### PR TITLE
message.context.messageAcked -> message.messageAcked

### DIFF
--- a/lib/mock-channel-factory.js
+++ b/lib/mock-channel-factory.js
@@ -13,17 +13,15 @@ function mockChannelFactory (isConsumerChannel) {
     ack: function (message) {
       // emulate consumeChannel behavior from coworkers/lib/rabbit-utils/app-channel-create.js
       if (isConsumerChannel) {
-        const context = message.context
-        assert(!context.messageAcked, 'Messages cannot be acked/nacked more than once (will close channel)')
-        context.messageAcked = true
+        assert(!message.messageAcked, 'Messages cannot be acked/nacked more than once (will close channel)')
+        message.messageAcked = true
       }
     },
     nack: function (message/*, allUpTo, requeue*/) {
       // emulate consumeChannel behavior from coworkers/lib/rabbit-utils/app-channel-create.js
       if (isConsumerChannel) {
-        const context = message.context
-        assert(!context.messageAcked, 'Messages cannot be acked/nacked more than once (will close channel)')
-        context.messageAcked = true
+        assert(!message.messageAcked, 'Messages cannot be acked/nacked more than once (will close channel)')
+        message.messageAcked = true
       }
     },
     ackAll: function (message) {

--- a/test/mock-channel.unit.js
+++ b/test/mock-channel.unit.js
@@ -25,14 +25,14 @@ describe('mockChannel', function () {
       const message = { context: {} }
       ctx.mockChannel.ack(message)
       // assert that consumerChannel logic is not run
-      expect(message.context.messageAcked).to.not.exist()
+      expect(message.messageAcked).to.not.exist()
       done()
     })
     it('should publisherChannel.nack', function (done) {
       const message = { context: {} }
       ctx.mockChannel.nack(message)
       // assert that consumerChannel logic is not run
-      expect(message.context.messageAcked).to.not.exist()
+      expect(message.messageAcked).to.not.exist()
       done()
     })
   })
@@ -48,7 +48,7 @@ describe('mockChannel', function () {
       const message = { context: {} }
       ctx.mockChannel.ack(message)
       // assert that consumerChannel logic is run
-      expect(message.context.messageAcked).to.be.true()
+      expect(message.messageAcked).to.be.true()
       expect(
         ctx.mockChannel.ack.bind(ctx.mockChannel, message)
       ).to.throw(/cannot/)
@@ -58,7 +58,7 @@ describe('mockChannel', function () {
       const message = { context: {} }
       ctx.mockChannel.nack(message)
       // assert that consumerChannel logic is run
-      expect(message.context.messageAcked).to.be.true()
+      expect(message.messageAcked).to.be.true()
       expect(
         ctx.mockChannel.nack.bind(ctx.mockChannel, message)
       ).to.throw(/cannot/)


### PR DESCRIPTION
`message.context` does not exist in coworkers@0.5.x

changed `coworkers-test` to mirror the latest version of coworkers and changed all `message.context.messageAcked` -> `message.messageAcked`
